### PR TITLE
Created github release publish yml

### DIFF
--- a/.github/workflows/android-create-release.yml
+++ b/.github/workflows/android-create-release.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   fetch_latest_release_notes_publish_release:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Parse out latest release notes

--- a/.github/workflows/android-create-release.yml
+++ b/.github/workflows/android-create-release.yml
@@ -11,6 +11,8 @@ on:
   pull_request:
     branches: [ "develop" ]
 
+env:
+  GITHUB_TOKEN: ${{ secrets.TOKEN_TO_PUBLISH_RELEASE_LUCRA_SDK }}
 
 jobs:
   fetch_latest_release_notes_publish_release:

--- a/.github/workflows/android-create-release.yml
+++ b/.github/workflows/android-create-release.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           OUTPUT=$(awk '/^## / { if(found) exit; if(!found) { version=$2; found=1; next } } found && !/^## / { notes = notes (notes ? ORS : "") $0 } END { print version; print notes }' SDK_RELEASE_NOTES.md)
           VERSION=$(echo "$OUTPUT" | head -1)
+          RELEASE_NOTES=$(echo "$OUTPUT" | tail -n +2)
           RELEASE_NOTES_JSON=$(jq -R -s '.' <<< "$RELEASE_NOTES")
   
           curl -L -v \

--- a/.github/workflows/android-create-release.yml
+++ b/.github/workflows/android-create-release.yml
@@ -31,4 +31,4 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${GITHUB_TOKEN}" \
             https://api.github.com/repos/${OWNER}/${REPO}/releases \
-            -d "{\"tag_name\":\"${VERSION}\",\"name\":\"${VERSION}\",\"body\":\"${RELEASE_NOTES}\",\"draft\":false,\"prerelease\":false}"
+            -d "{\"tag_name\":\"${VERSION}\",\"name\":\"${VERSION}\",\"body\":\"${RELEASE_NOTES}\",\"draft\":true,\"prerelease\":false}"

--- a/.github/workflows/android-create-release.yml
+++ b/.github/workflows/android-create-release.yml
@@ -28,12 +28,11 @@ jobs:
         run: |
           OUTPUT=$(awk '/^## / { if(found) exit; if(!found) { version=$2; found=1; next } } found && !/^## / { notes = notes (notes ? ORS : "") $0 } END { print version; print notes }' SDK_RELEASE_NOTES.md)
           VERSION=$(echo "$OUTPUT" | head -1)
-          RELEASE_NOTES=$(echo "$OUTPUT" | tail -n +2)
-          RELEASE_NOTES="${RELEASE_NOTES//$'\n'/'%0A'}"
-          
+          RELEASE_NOTES_JSON=$(jq -R -s '.' <<< "$RELEASE_NOTES")
+  
           curl -L -v \
             -X POST \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${GITHUB_TOKEN}" \
             https://api.github.com/repos/${OWNER}/${REPO}/releases \
-            -d "{\"tag_name\":\"${VERSION}\",\"name\":\"${VERSION}\",\"body\":\"${RELEASE_NOTES}\",\"draft\":true,\"prerelease\":false}"
+            -d "{\"tag_name\":\"${VERSION}\",\"name\":\"${VERSION}\",\"body\":${RELEASE_NOTES_JSON},\"draft\":true,\"prerelease\":false}"

--- a/.github/workflows/android-create-release.yml
+++ b/.github/workflows/android-create-release.yml
@@ -13,6 +13,9 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.TOKEN_TO_PUBLISH_RELEASE_LUCRA_SDK }}
+  OWNER: Lucra-Sports
+  REPO: lucra-android-sdk
+
 
 jobs:
   fetch_latest_release_notes_publish_release:

--- a/.github/workflows/android-create-release.yml
+++ b/.github/workflows/android-create-release.yml
@@ -7,9 +7,6 @@ on:
     paths:
       - 'SDK_RELEASE_NOTES.md'
   workflow_dispatch:
-  # TODO remove this before merging
-  pull_request:
-    branches: [ "develop" ]
 
 env:
   GITHUB_TOKEN: ${{ secrets.TOKEN_TO_PUBLISH_RELEASE_LUCRA_SDK }}
@@ -29,7 +26,7 @@ jobs:
           OUTPUT=$(awk '/^## / { if(found) exit; if(!found) { version=$2; found=1; next } } found && !/^## / { notes = notes (notes ? ORS : "") $0 } END { print version; print notes }' SDK_RELEASE_NOTES.md)
           VERSION=$(echo "$OUTPUT" | head -1)
           RELEASE_NOTES=$(echo "$OUTPUT" | tail -n +2)
-          RELEASE_NOTES_JSON=$(jq -R -s '.' <<< "$RELEASE_NOTES")
+          RELEASE_NOTES_JSON=$(jq -R -s '.' <<< "$RELEASE_NOTES") # to escape new lines
   
           curl -L -v \
             -X POST \

--- a/.github/workflows/android-create-release.yml
+++ b/.github/workflows/android-create-release.yml
@@ -1,0 +1,34 @@
+name: Create Release from latest release notes
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'SDK_RELEASE_NOTES.md'
+  workflow_dispatch:
+  # TODO remove this before merging
+  pull_request:
+    branches: [ "develop" ]
+
+
+jobs:
+  fetch_latest_release_notes_publish_release:
+    runs-on: buildjet-8vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v3
+      - name: Parse out latest release notes
+        id: latest_release_notes
+        # This looks for the last version added, takes the version and collects the notes below it
+        run: |
+          OUTPUT=$(awk '/^## / { if(found) exit; if(!found) { version=$2; found=1; next } } found && !/^## / { notes = notes (notes ? ORS : "") $0 } END { print version; print notes }' SDK_RELEASE_NOTES.md)
+          VERSION=$(echo "$OUTPUT" | head -1)
+          RELEASE_NOTES=$(echo "$OUTPUT" | tail -n +2)
+          RELEASE_NOTES="${RELEASE_NOTES//$'\n'/'%0A'}"
+          
+          curl -L -v \
+            -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
+            https://api.github.com/repos/${OWNER}/${REPO}/releases \
+            -d "{\"tag_name\":\"${VERSION}\",\"name\":\"${VERSION}\",\"body\":\"${RELEASE_NOTES}\",\"draft\":false,\"prerelease\":false}"

--- a/.github/workflows/android-nightly-check-update-sdk-interaction-branch.yml
+++ b/.github/workflows/android-nightly-check-update-sdk-interaction-branch.yml
@@ -1,8 +1,8 @@
-name: Nightly PR Creation from update/sdk-interaction to develop
+name: Create PR for update/sdk-interaction after package release
 
 on:
-  schedule:
-    - cron: '0 0 * * *'  # Run every day at midnight
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:

--- a/SDK_RELEASE_NOTES.md
+++ b/SDK_RELEASE_NOTES.md
@@ -1,5 +1,3 @@
-# Release Notes
-## Upcoming Release Changes
 ## 2.3.0-beta
 * Fixed issues around missing matchups
 * Fixed user balance emission updates


### PR DESCRIPTION
## Update PR changes
* A PR is no longer created upon every change made in the private repo
* The PR is created when new artifacts are published, allowing for the latest version to be fetched as expected
* If the PR contains changes to SDK_RELEASE_NOTES (it should if we created a new artifact), then it'll kick off the github release automation, noted below

## Public Github Release Creation
* Upon SDK_RELEASE_NOTES update, a new public release will be created, parsing out the latest version of the release notes to the best of it's ability.
* This can only happen after the pending changes PR is merged into `develop` with release notes changes
