### PR TITLE
[DO NOT MERGE] Emulating compose + kotlin version clashing

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.23" />
+    <option name="version" value="2.0.21" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,12 +42,12 @@ android {
         buildConfigField(
             "String",
             "TESTING_API_KEY",
-            "\"BHGhy6w9eOPoU7z1UdHffuDNdlihYU6T\""
+            "\"YOUR API KEY HERE\""
         )
         buildConfigField(
             "String",
             "TESTING_API_URL",
-            "\"api-sample.staging.lucrasports.com\""
+            "\"YOUR API URL HERE\""
         )
 
         // TODO this is just for our example, not required for your app!

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,21 +1,25 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
 }
 val mavenVersion = project.findProperty("publishVersion") as String
+val composeBomVersion = "2025.09.01"
+val navigationComposeVersion = "2.9.3"
 
 android {
     namespace = "com.lucrasports.sdk.app"
-    compileSdk = 34
+    compileSdk = 35
 
     buildFeatures {
         buildConfig = true
+        compose = true
     }
 
     defaultConfig {
         applicationId = "com.lucrasports.sdk.app"
         minSdk = 24
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = mavenVersion
 
@@ -35,17 +39,15 @@ android {
         manifestPlaceholders["branchio-key"] = "not-needed-internal-code-reference-only"
         manifestPlaceholders["branchio-key-test"] = "not-needed-internal-code-reference-only"
 
-        // TODO Add your auth0 client id here
         buildConfigField(
             "String",
             "TESTING_API_KEY",
-            "\"ADD YOUR API KEY HERE\""
+            "\"BHGhy6w9eOPoU7z1UdHffuDNdlihYU6T\""
         )
-        // TODO Add your auth0 domain url here
         buildConfigField(
             "String",
             "TESTING_API_URL",
-            "\"ADD YOUR API URL HERE\""
+            "\"api-sample.staging.lucrasports.com\""
         )
 
         // TODO this is just for our example, not required for your app!
@@ -84,6 +86,10 @@ android {
 }
 
 dependencies {
+    implementation(platform("androidx.compose:compose-bom:$composeBomVersion"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:$composeBomVersion"))
+    debugImplementation(platform("androidx.compose:compose-bom:$composeBomVersion"))
+
     implementation("com.lucrasports.sdk:sdk-ui:$mavenVersion")
 
     // For testing internal UI of the reward flow - not required for client integration
@@ -105,13 +111,41 @@ dependencies {
     implementation("com.google.firebase:firebase-crashlytics")
     implementation("com.google.firebase:firebase-analytics")
     implementation("com.google.firebase:firebase-messaging")
-    implementation("com.jaredrummler:colorpicker:1.1.0")
+    implementation("com.google.firebase:firebase-dynamic-links:21.1.0")
+
+    implementation("androidx.activity:activity-compose:1.9.3")
+    implementation("androidx.compose.animation:animation")
+    implementation("androidx.compose.animation:animation-core")
+    implementation("androidx.compose.animation:animation-graphics")
+    implementation("androidx.compose.foundation:foundation")
+    implementation("androidx.compose.foundation:foundation-layout")
+    implementation("androidx.compose.material:material")
+    implementation("androidx.compose.material:material-icons-extended")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material3:material3-window-size-class")
+    implementation("androidx.compose.runtime:runtime")
+    implementation("androidx.compose.runtime:runtime-livedata")
+    implementation("androidx.compose.runtime:runtime-rxjava2")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-graphics")
+    implementation("androidx.compose.ui:ui-text")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.ui:ui-util")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.9.0")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.0")
+    implementation("androidx.navigation:navigation-compose:$navigationComposeVersion")
+
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
     testImplementation("org.reflections:reflections:0.9.12")
     testImplementation("io.mockk:mockk:1.12.0")
+
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-    implementation("com.google.firebase:firebase-dynamic-links:21.1.0")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
 
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+    debugImplementation("androidx.compose.ui:ui-tooling")
+
+    implementation("com.jaredrummler:colorpicker:1.1.0")
 }

--- a/app/src/main/java/com/lucrasports/sdk/app/MainActivitySdk.kt
+++ b/app/src/main/java/com/lucrasports/sdk/app/MainActivitySdk.kt
@@ -209,7 +209,7 @@ class MainActivitySdk : AppCompatActivity(), ColorPickerDialogListener {
             apiKey = apiKeyOverride ?: BuildConfig.TESTING_API_KEY,
             // This must be updated to the correct api url per environment
             apiUrl = apiUrlOverride ?: BuildConfig.TESTING_API_URL,
-            environment = getEnvironmentFromBuildType(),
+            environment = Environment.STAGING,
             outputLogs = true,
             customLogger = customLogger,
             clientTheme = ClientTheme(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.3.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.23" apply false
+    id("com.android.application") version "8.7.3" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+    id("org.jetbrains.kotlin.jvm") version "2.0.21"
+    id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
 }
 
 allprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri May 17 13:27:34 MST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
We updated this sample host app to emulate the navigation-argument regression introduced when `com.lucrasports.sdk:sdk-ui:4.2.1` runs inside an app already targeting AGP 8.7.3, Gradle 8.11, Kotlin 2.0.21 (android/jvm/compose plugins), compile/target SDK 35, Navigation Compose 2.9.3, and the `androidx.compose:compose-bom:2025.09.01` stack (Compose 1.9.2 line).

Two remediation published versions are available:

* `com.lucrasports.sdk:sdk-ui:4.2.1-forward-compat-fix-1` — keeps the existing dependency matrix and layers in the forward-compatibility code fix. With no toolchain upgrades, the blast radius is tiny, making this the lowest-risk unblock for integrators.
* `com.lucrasports.sdk:sdk-ui:4.2.1-dep-update-fix-1` — ships the same code fix plus the full dependency alignment to Kotlin 2.0.21 / Compose 1.9.2 / Navigation 2.9.3. It has passed focused regression, but because the blast radius covers the entire upgraded stack, we’re treating it as higher risk until the extended certification cycle finishes.

_Plan of record: releases after 4.5.1 will adopt the full toolchain upgrade by default, so the higher baseline will be covered in our standard qualification runs._